### PR TITLE
Disable no-new error

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -148,7 +148,8 @@ module.exports = {
     'no-multi-str': 'error',
 
     // disallow use of new operator when not part of the assignment or comparison
-    'no-new': 'error',
+    // => we need new for 3rd party APIS
+    'no-new': 'warn',
 
     // disallow use of new operator for Function object
     'no-new-func': 'error',

--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -149,7 +149,7 @@ module.exports = {
 
     // disallow use of new operator when not part of the assignment or comparison
     // => we need new for 3rd party APIS
-    'no-new': 'warn',
+    'no-new': 'off',
 
     // disallow use of new operator for Function object
     'no-new-func': 'error',


### PR DESCRIPTION
We are working with many 3rd party OO apis such as Vue.js. We cant create new instances without using the `new` keyword.
And doing this is silly
```
/* eslint-disable no-new */
new Vue({
```