### PR TITLE
property reassignment for 3rd party libraries

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/best-practices.js
+++ b/packages/eslint-config-airbnb-base/rules/best-practices.js
@@ -167,17 +167,7 @@ module.exports = {
     // disallow parameter object manipulation except for specific exclusions
     // rule: http://eslint.org/docs/rules/no-param-reassign.html
     'no-param-reassign': ['error', {
-      props: true,
-      ignorePropertyModificationsFor: [
-        'acc', // for reduce accumulators
-        'e', // for e.returnvalue
-        'ctx', // for Koa routing
-        'req', // for Express requests
-        'request', // for Express requests
-        'res', // for Express responses
-        'response', // for Express responses
-        '$scope', // for Angular 1 scopes
-      ]
+      props: false
     }],
 
     // disallow usage of __proto__ property


### PR DESCRIPTION
It's currently not possible modify an object property within a function call. This makes it impossible to work with Leaflet objects and other 3rd party libraries. The list of exceptions by airbnb is focused on nodejs. In the frontend we have way too many exceptions to list and maintain in the lint rules. We would have to list and maintain every property of a leaflet instance and other libraries, resulting in hundreds of exceptions.

The airbnb example doesn't even make sense as its not producing the same result.

```
// bad
function f1(obj) {
  obj.key = 1;
}

// good
function f2(obj) {
 // hello airbnb this is something entirely different ???
  const key = Object.prototype.hasOwnProperty.call(obj, 'key') ? obj.key : 1;
}
```

Additionally, this rule is easily bypassed by using _.set
And also this is totally legit though it reassigns the original object because we dont clone it.

```
// why is this ok ?
function f1(original) {
  const copy = original // just a reference
  copy.key = 1; // this should throw a lint error but it fails to track it
}
```